### PR TITLE
Fixes a broken change, and make super() consistent

### DIFF
--- a/FrEIA/framework.py
+++ b/FrEIA/framework.py
@@ -195,7 +195,7 @@ class OutputNode(Node):
     class dummy(nn.Module):
 
         def __init__(self, *args):
-            super(OutputNode.dummy, self).__init__()
+            super().__init__()
 
         def __call__(*args):
             return args
@@ -229,7 +229,7 @@ class ReversibleGraphNet(nn.Module):
         '''node_list should be a list of all nodes involved, and ind_in,
         ind_out are the indexes of the special nodes InputNode and OutputNode
         in this list.'''
-        super(ReversibleGraphNet, self).__init__()
+        super().__init__()
 
         # Gather lists of input, output and condition nodes
         if ind_in is not None:

--- a/FrEIA/modules/coeff_functs.py
+++ b/FrEIA/modules/coeff_functs.py
@@ -11,7 +11,7 @@ class F_conv(nn.Module):
     def __init__(self, in_channels, channels, channels_hidden=None,
                  stride=None, kernel_size=3, leaky_slope=0.1,
                  batch_norm=False):
-        super(F_conv, self).__init__()
+        super().__init__()
 
         if stride:
             warnings.warn("Stride doesn't do anything, the argument should be "
@@ -61,7 +61,7 @@ class F_fully_connected(nn.Module):
     '''Fully connected tranformation, not reversible, but used below.'''
 
     def __init__(self, size_in, size, internal_size=None, dropout=0.0):
-        super(F_fully_connected, self).__init__()
+        super().__init__()
         if not internal_size:
             internal_size = 2*size
 

--- a/FrEIA/modules/inv_auto_layers.py
+++ b/FrEIA/modules/inv_auto_layers.py
@@ -38,7 +38,7 @@ class InvAutoActTwoSided(nn.Module):
 class InvAutoAct(nn.Module):
 
     def __init__(self, dims_in):
-        super(InvAutoAct, self).__init__()
+        super().__init__()
         self.alpha = nn.Parameter(0.01 * torch.randn(dims_in[0][0]) + 0.7)
 
     def forward(self, x, rev=False):
@@ -78,7 +78,7 @@ class InvAutoActFixed(nn.Module):
 class LearnedElementwiseScaling(nn.Module):
 
     def __init__(self, dims_in):
-        super(ScalingLayer, self).__init__()
+        super().__init__()
         self.s = nn.Parameter(torch.zeros(*dims_in[0]))
 
     def forward(self, x, rev=False):
@@ -95,7 +95,7 @@ class LearnedElementwiseScaling(nn.Module):
 class InvAutoFC(nn.Module):
 
     def __init__(self, dims_in, dims_out=None):
-        super(InvAutoFC, self).__init__()
+        super().__init__()
         self.dims_in = dims_in
         if dims_out is None:
             self.dims_out = deepcopy(dims_in)
@@ -119,7 +119,7 @@ class InvAutoFC(nn.Module):
 class InvAutoConv2D(nn.Module):
 
     def __init__(self, dims_in, dims_out, kernel_size=3, padding=1):
-        super(InvAutoConv2D, self).__init__()
+        super().__init__()
         self.dims_in = dims_in
         self.dims_out = dims_out
         self.kernel_size = kernel_size


### PR DESCRIPTION
This PR updates all existing `super()` calls to the new style (i.e. without including `ClassName` and `self` in the `super()` argument.

Most of the existing ones are harmless; however, what I am interested in is at
https://github.com/VLL-HD/FrEIA/blob/17faa829ecab2548d949558f92c79a142a7e9b96/FrEIA/modules/inv_auto_layers.py#L81
where it causes an Exception because it references `ScalingLayer` within the class `LearnedElementwiseScaling` for the `super()` calls (but it was never defined). I am guessing `ScalingLayer`  was the older name for that class, but the author forgot to update the `super()` call. 

This is the relevant traceback:
```python
Traceback (most recent call last):
  File "train.py", line 76, in <module>
    xxxxxxxxx
  File "site-packages/FrEIA/framework.py", line 274, in __init__
    node_list[i].build_modules(verbose=verbose)
  File "site-packages/FrEIA/framework.py", line 63, in build_modules
    self.input_dims = [n.build_modules(verbose=verbose)[c]
...
  File "site-packages/FrEIA/framework.py", line 63, in <listcomp>
    self.input_dims = [n.build_modules(verbose=verbose)[c]
  File "site-packages/FrEIA/framework.py", line 75, in build_modules
    raise e
  File "site-packages/FrEIA/framework.py", line 71, in build_modules
    self.module = self.module_type(self.input_dims,
  File "site-packages/FrEIA/modules/inv_auto_layers.py", line 81, in __init__
    super(ScalingLayer, self).__init__()
NameError: name 'ScalingLayer' is not defined
```

The codebase had a mix of the older and newer style of `super()`. It will be cleaner and make refactoring easier when using the new style `super()`. All existing ones that I can find had been updated to the newer style in this PR.