### PR TITLE
include fasth2

### DIFF
--- a/FrEIA/modules/orthogonal.py
+++ b/FrEIA/modules/orthogonal.py
@@ -2,6 +2,63 @@ import torch
 import torch.nn as nn
 import numpy as np
 
+def _fast_h(v, stride=2):
+    """
+    Fast product of a series of Householder matrices. This implementation is oriented to the one introducesd in:
+    https://invertibleworkshop.github.io/accepted_papers/pdfs/10.pdf
+    This makes use of method 2 in: https://ecommons.cornell.edu/bitstream/handle/1813/6521/85-681.pdf?sequence=1&isAllowed=y
+
+    :param v: Batched series of Householder matrices. The last dim is the dim of one vector and the second last is the
+    number of elements in one product. This is the min amount of dims that need to be present.
+    All further ones are considered batch dimensions.
+    :param stride: Controls the number of parallel operations by the WY representation (see paper)
+    should not be larger than half the number of matrices in one product.
+    :return: The batched product of Householder matrices defined by v
+    """
+    assert v.ndim > 1
+    assert stride <= v.shape[-2]
+
+    d, m = v.shape[-2], v.shape[-1]
+    k = d // stride
+    last = k * stride
+    v = v / torch.norm(v, dim=-1, p=2, keepdim=True)
+    v = v.unsqueeze(-1)
+    u = 2 * v
+    ID = torch.eye(m, device=u.device)
+    for dim in range(v.ndim-3):
+        ID = ID.unsqueeze(0)
+
+    # step 1 (compute intermediate groupings P_i)
+    W = u[..., 0:last:stride, :, :]
+    Y = v[..., 0:last:stride, :, :]
+
+    for idx in range(1, stride):
+        Pt = ID - torch.matmul(u[..., idx:last:stride, :, :], v[..., idx:last:stride, :, :].transpose(-1, -2))
+        W = torch.cat([W, u[..., idx:last:stride, :, :]], dim=-1)
+        Y = torch.cat([torch.matmul(Pt, Y), v[..., idx:last:stride, :, :]], dim=-1)
+
+    # step 2 (multiply the WY reps)
+    P = ID - torch.matmul(W[..., k-1, :, :], Y[..., k-1, :, :].transpose(-1, -2))
+    for idx in reversed(range(0, k-1)):
+        P = P - torch.matmul(W[..., idx, :, :], torch.matmul(Y[..., idx, :, :].transpose(-1, -2), P))
+
+    # deal with the residual, using a stride of 2 here maxes the amount of parallel ops
+    if d > last:
+        even_end = d if (d-last) % 2 == 0 else d - 1
+        W_resi = u[..., last:even_end:2, :, :]
+        Y_resi = v[..., last:even_end:2, :, :]
+        for idx in range(last+1, d if d == last+1 else last+2):
+            Pt = ID - torch.matmul(u[..., idx:even_end:2, :, :], v[..., idx:even_end:2, :, :].transpose(-1, -2))
+            W_resi = torch.cat([W_resi, u[..., idx:even_end:2, :, :]], dim=-1)
+            Y_resi = torch.cat([torch.matmul(Pt, Y_resi), v[..., idx:even_end:2, :, :]], dim=-1)
+
+        for idx in range(0, W_resi.shape[-3]):
+            P = P - torch.matmul(P, torch.matmul(W_resi[..., idx, :, :], Y_resi[..., idx, :, :].transpose(-1, -2)))
+
+        if even_end != d:
+            P = P - torch.matmul(P, torch.matmul(u[..., -1, :, :], v[..., -1, :, :].transpose(-1, -2)))
+
+    return P
 
 def orth_correction(R):
     R[0] /= torch.norm(R[0])
@@ -82,49 +139,32 @@ class HouseholderPerm(nn.Module):
                 # init close to identity
                 init = torch.eye(self.width, self.n_reflections)
                 init += torch.randn_like(init) * 0.1
-            Vs = torch.unbind(init, dim=-1)
-            self.Vs = [nn.Parameter(V) for V in Vs]
-            for i, V in enumerate(self.Vs):
-                V.requires_grad = not self.fixed
-                self.register_parameter(f'V_{i}', V)
+            Vs = init.transpose(-1, -2)
+            self.Vs = nn.Parameter(Vs)
+
+            Vs.requires_grad = not self.fixed
+            self.register_parameter(f'Vs', self.Vs)
 
         if self.fixed:
-            I = torch.eye(self.width)
-            self.W = I - 2 * torch.ger(self.Vs[0], self.Vs[0]) / torch.dot(self.Vs[0], self.Vs[0])
-            for i in range(1, self.n_reflections):
-                self.W = self.W.mm(I - 2 * torch.ger(self.Vs[i], self.Vs[i]) / torch.dot(self.Vs[i], self.Vs[i]))
+            self.W = _fast_h(self.Vs)
             self.W = nn.Parameter(self.W, requires_grad=False)
             self.register_parameter('weight', self.W)
 
     def forward(self, x, c=[], rev=False):
 
         if self.conditional:
-            Vs = torch.unbind(c[0].reshape(-1, self.width, self.n_reflections), dim=-1)
-
-            xW = x[0]
-            for i in range(self.n_reflections):
-                if not rev:
-                    V = Vs[i]
-                else:
-                    V = Vs[-i - 1]
-                VVt = torch.matmul(V.unsqueeze(-1), V.unsqueeze(-2))
-                VtV = torch.matmul(V.unsqueeze(-2), V.unsqueeze(-1)).squeeze(-1)
-                xW = xW - torch.matmul(xW.unsqueeze(-2), VVt).squeeze() * (2/VtV)
-            return [xW]
-
+            Vs = c[0].reshape(-1, self.width, self.n_reflections).transpose(-1, -2)
+            W = _fast_h(Vs)
         else:
             if self.fixed:
                 W = self.W
             else:
-                I = torch.eye(self.width, device=x[0].device)
-                W = I - 2 * torch.ger(self.Vs[0], self.Vs[0]) / torch.dot(self.Vs[0], self.Vs[0])
-                for i in range(1, self.n_reflections):
-                    W = W.mm(I - 2 * torch.ger(self.Vs[i], self.Vs[i]) / torch.dot(self.Vs[i], self.Vs[i]))
+                W = _fast_h(self.Vs)
 
-            if not rev:
-                return [x[0].mm(W)]
-            else:
-                return [x[0].mm(W.t())]
+        if not rev:
+            return [x[0].mm(W)]
+        else:
+            return [x[0].mm(W.transpose(-1, -2))]
 
 
     def jacobian(self, x, rev=False):

--- a/tests/orthogonal_layer.py
+++ b/tests/orthogonal_layer.py
@@ -13,10 +13,11 @@ inp_size = 100
 
 inp = InputNode(inp_size, name='input')
 orthog_layer = Node([inp.out0], orthogonal_layer, {'correction_interval':100})
-permute = Node([orthog_layer.out0], permute_layer, {'seed':0})
-outp= OutputNode([permute.out0], name='output')
+permute_1 = Node([orthog_layer.out0], permute_layer, {'seed':0})
+permute_2 = Node([permute_1.out0], HouseholderPerm, {'n_reflections':10})
+outp= OutputNode([permute_2.out0], name='output')
 
-test_net = ReversibleGraphNet([inp, orthog_layer, permute, outp])
+test_net = ReversibleGraphNet([inp, orthog_layer, permute_1, permute_2, outp])
 
 optim = torch.optim.SGD(test_net.parameters(), lr=5e-1)
 


### PR DESCRIPTION
Hi @wapu , I included my implementation for a "fast" Householder product. You will find the final project report under https://github.com/paulhfu/Faster-Orthogonal-Parameterization-with-Householder-Matrices/blob/master/report/report.pdf 
All my implementations are in https://github.com/paulhfu/Faster-Orthogonal-Parameterization-with-Householder-Matrices/blob/master/FastH/fast_h.py 
Some tests are in https://github.com/paulhfu/Faster-Orthogonal-Parameterization-with-Householder-Matrices/blob/master/test/test_fast_h.py 
I also altered the tests in this repo to include Householder perms. Let me know if I should revert that.