### PR TITLE
Fix typo in one of the asserts in `framework.parse_input`

### DIFF
--- a/FrEIA/framework.py
+++ b/FrEIA/framework.py
@@ -50,7 +50,7 @@ class Node:
                 raise RuntimeError(f"Cannot parse inputs provided to node '{self.name}'.")
         else:
             assert isinstance(inputs, Node), "Received object of invalid type "\
-                f"({type(inputs)}) as input for node '{name}'."
+                f"({type(inputs)}) as input for node '{self.name}'."
             return [(inputs, 0),]
 
     def build_modules(self, verbose=True):


### PR DESCRIPTION
Assert text was using 'name' instead of 'self.name', causing an 
AttributeError to be raised and hiding the useful error message.