### PR TITLE
expose base class in init file to make it testable

### DIFF
--- a/FrEIA/modules/__init__.py
+++ b/FrEIA/modules/__init__.py
@@ -5,6 +5,7 @@ needed compared to the base class is an @staticmethod otuput_dims, and the
 
 Coupling blocks:
 
+* InvertibleModule
 * AllInOneBlock
 * NICECouplingBlock
 * RNVPCouplingBlock
@@ -60,6 +61,7 @@ from .orthogonal import *
 from .inv_auto_layers import *
 from .invertible_resnet import *
 from .gaussian_mixture import *
+from .base import *
 
 __all__ = [
             'AllInOneBlock',
@@ -76,6 +78,7 @@ __all__ = [
             'InvAutoActTwoSided',
             'InvAutoConv2D',
             'InvAutoFC',
+            'InvertibleModule',
             'LearnedElementwiseScaling',
             'orthogonal_layer',
             'conv_1x1',


### PR DESCRIPTION
The `InvertibleModule` by @tbung was not exposed in the `modules` subpackage. This fixes this so that the class becomes testable. 