### PR TITLE
(minor) Update AssertionError message in coupling_layers.py

### DIFF
--- a/FrEIA/modules/coupling_layers.py
+++ b/FrEIA/modules/coupling_layers.py
@@ -43,7 +43,7 @@ class _BaseCouplingBlock(InvertibleModule):
         self.clamp = clamp
 
         assert all([tuple(dims_c[i][1:]) == tuple(dims_in[0][1:]) for i in range(len(dims_c))]), \
-            "Dimensions of input and one or more conditions don't agree."
+            F"Dimensions of input {dims_in} and one or more conditions {dims_c} don't agree."
         self.conditional = (len(dims_c) > 0)
         self.condition_length = sum([dims_c[i][0] for i in range(len(dims_c))])
 


### PR DESCRIPTION
Minor edit to add dimensionality information to this AssertionError. This makes the error more informative similar to all_in_one_block.py, which uses a similar assert statement.